### PR TITLE
Support Python 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Available under the ISC License.
 
 Prerequisites
 -------------
-* Python >=2.7 or 3.x
+* Python >=2.6 or 3.x
 * ykchalresp (found in the yubikey-personalization package)
 * Yubikey
 * [Cross-platform GUI Personalization tool][tool]

--- a/yubi_goog.py
+++ b/yubi_goog.py
@@ -104,7 +104,15 @@ def yubi():
         cmd.append('ykchalresp')
         cmd.append('-2x')
         cmd.append(chal)
-        resp = subprocess.check_output(cmd).strip()
+        if hasattr(subprocess, "check_output"):
+            resp = subprocess.check_output(cmd).strip()
+        else:
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+            out, err = proc.communicate()
+            if not isinstance(out, basestring):
+                raise ValueError("Command {0} returned {1!r}."
+                                 .format(" ".join(cmd), out))
+            resp = out.strip()
         print("OTP: %s" %(mangle_hash(binascii.unhexlify(resp))))
 
 def error():


### PR DESCRIPTION
These changes allow your script to support Python 2.6 which does not provide subprocess.check_output.
