### PR TITLE
Gracefully handle missing key error

### DIFF
--- a/yubi_goog.py
+++ b/yubi_goog.py
@@ -105,7 +105,10 @@ def yubi():
         cmd.append('-2x')
         cmd.append(chal)
         if hasattr(subprocess, "check_output"):
-            resp = subprocess.check_output(cmd).strip()
+            try:
+                resp = subprocess.check_output(cmd).strip()
+            except subprocess.CalledProcessError:
+                sys.exit(1)
         else:
             proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
             out, err = proc.communicate()


### PR DESCRIPTION
if no yubi is inserted prog terminates like 

$ ./yubi_goog.py --yubi
Yubikey core error: no yubikey present
Traceback (most recent call last):
  File "./yubi_goog.py", line 128, in <module>
    yubi(False)
  File "./yubi_goog.py", line 106, in yubi
    resp = subprocess.check_output(cmd).strip()
  File "/usr/lib/python2.7/subprocess.py", line 544, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command '['ykchalresp', '-2x', '0000xxxxxxxxx]' returned non-zero exit status 1

This patch handles missing key gracefully
